### PR TITLE
Include default timeout value from interface

### DIFF
--- a/src/AmqpConsumer.php
+++ b/src/AmqpConsumer.php
@@ -6,7 +6,7 @@ use Interop\Queue\PsrConsumer;
 
 /**
  * @method AmqpMessage|null receiveNoWait()
- * @method AmqpMessage|null receive(int $timeout)
+ * @method AmqpMessage|null receive(int $timeout = 0)
  * @method AmqpQueue getQueue()
  * @method void acknowledge(AmqpMessage $message)
  * @method void reject(AmqpMessage $message, bool $requeue)


### PR DESCRIPTION
Both the interface (`Interop\Queue\PsrConsumer`) and the implementations for Enqueue (for example `Enqueue\AmqpBunny\AmqpConsumer`) seem to have a default value for the `receive()` method's first and only parameter `$timeout`. This default value (`0`) isn't included in the `@method` annotation in `Interop\Queue\PsrConsumer\AmqpConsumer` which makes code completion in an IDE give a false positive when leaving out the (optional) parameter.

Including this default value in the annotation fixes this problem. There is no effect on the actual functionality or operation of this interop library or any of it's decendants.