### PR TITLE
Explicit nullable types

### DIFF
--- a/src/AmqpConsumer.php
+++ b/src/AmqpConsumer.php
@@ -20,7 +20,7 @@ interface AmqpConsumer extends Consumer
     const FLAG_EXCLUSIVE = 4;
     const FLAG_NOWAIT = 8;
 
-    public function setConsumerTag(string $consumerTag = null): void;
+    public function setConsumerTag(?string $consumerTag = null): void;
 
     public function getConsumerTag(): ?string;
 

--- a/src/AmqpMessage.php
+++ b/src/AmqpMessage.php
@@ -14,27 +14,27 @@ interface AmqpMessage extends Message
     const FLAG_MANDATORY = 1;
     const FLAG_IMMEDIATE = 2;
 
-    public function setContentType(string $type = null): void;
+    public function setContentType(?string $type = null): void;
 
     public function getContentType(): ?string;
 
-    public function setContentEncoding(string $encoding = null): void;
+    public function setContentEncoding(?string $encoding = null): void;
 
     public function getContentEncoding(): ?string;
 
-    public function setDeliveryMode(int $deliveryMode = null): void;
+    public function setDeliveryMode(?int $deliveryMode = null): void;
 
     public function getDeliveryMode(): ?int;
 
-    public function setPriority(int $priority = null): void;
+    public function setPriority(?int $priority = null): void;
 
     public function getPriority(): ?int;
 
-    public function setExpiration(int $expiration = null): void;
+    public function setExpiration(?int $expiration = null): void;
 
     public function getExpiration(): ?int;
 
-    public function setDeliveryTag(int $deliveryTag = null): void;
+    public function setDeliveryTag(?int $deliveryTag = null): void;
 
     /**
      * https://www.rabbitmq.com/amqp-0-9-1-reference.html#domain.delivery-tag
@@ -43,7 +43,7 @@ interface AmqpMessage extends Message
 
     public function getConsumerTag(): ?string;
 
-    public function setConsumerTag(string $consumerTag = null): void;
+    public function setConsumerTag(?string $consumerTag = null): void;
 
     public function clearFlags(): void;
 
@@ -55,5 +55,5 @@ interface AmqpMessage extends Message
 
     public function getRoutingKey(): ?string ;
 
-    public function setRoutingKey(string $routingKey = null): void;
+    public function setRoutingKey(?string $routingKey = null): void;
 }

--- a/src/AmqpQueue.php
+++ b/src/AmqpQueue.php
@@ -28,5 +28,5 @@ interface AmqpQueue extends Queue, AmqpDestination
 
     public function getConsumerTag(): ?string;
 
-    public function setConsumerTag(string $consumerTag = null): void;
+    public function setConsumerTag(?string $consumerTag = null): void;
 }

--- a/src/Impl/AmqpBind.php
+++ b/src/Impl/AmqpBind.php
@@ -36,7 +36,7 @@ final class AmqpBind implements InteropAmqpBind
     public function __construct(
         AmqpDestination $target,
         AmqpDestination $source,
-        string $routingKey = null,
+        ?string $routingKey = null,
         int $flags = self::FLAG_NOPARAM,
         array $arguments = []
     ) {

--- a/src/Impl/AmqpMessage.php
+++ b/src/Impl/AmqpMessage.php
@@ -125,7 +125,7 @@ final class AmqpMessage implements InteropAmqpMessage
         return $this->redelivered;
     }
 
-    public function setCorrelationId(string $correlationId = null): void
+    public function setCorrelationId(?string $correlationId = null): void
     {
         $this->setHeader('correlation_id', $correlationId);
     }
@@ -135,7 +135,7 @@ final class AmqpMessage implements InteropAmqpMessage
         return $this->getHeader('correlation_id');
     }
 
-    public function setMessageId(string $messageId = null): void
+    public function setMessageId(?string $messageId = null): void
     {
         $this->setHeader('message_id', $messageId);
     }
@@ -152,12 +152,12 @@ final class AmqpMessage implements InteropAmqpMessage
         return $value === null ? null : (int) $value;
     }
 
-    public function setTimestamp(int $timestamp = null): void
+    public function setTimestamp(?int $timestamp = null): void
     {
         $this->setHeader('timestamp', $timestamp);
     }
 
-    public function setReplyTo(string $replyTo = null): void
+    public function setReplyTo(?string $replyTo = null): void
     {
         $this->setHeader('reply_to', $replyTo);
     }
@@ -167,7 +167,7 @@ final class AmqpMessage implements InteropAmqpMessage
         return $this->getHeader('reply_to');
     }
 
-    public function setContentType(string $type = null): void
+    public function setContentType(?string $type = null): void
     {
         $this->setHeader('content_type', $type);
     }
@@ -177,7 +177,7 @@ final class AmqpMessage implements InteropAmqpMessage
         return $this->getHeader('content_type');
     }
 
-    public function setContentEncoding(string $encoding = null): void
+    public function setContentEncoding(?string $encoding = null): void
     {
         $this->setHeader('content_encoding', $encoding);
     }
@@ -192,12 +192,12 @@ final class AmqpMessage implements InteropAmqpMessage
         return $this->getHeader('priority');
     }
 
-    public function setPriority(int $priority = null): void
+    public function setPriority(?int $priority = null): void
     {
         $this->setHeader('priority', $priority);
     }
 
-    public function setDeliveryMode(int $deliveryMode = null): void
+    public function setDeliveryMode(?int $deliveryMode = null): void
     {
         $this->setHeader('delivery_mode', $deliveryMode);
     }
@@ -207,7 +207,7 @@ final class AmqpMessage implements InteropAmqpMessage
         return $this->getHeader('delivery_mode');
     }
 
-    public function setExpiration(int $expiration = null): void
+    public function setExpiration(?int $expiration = null): void
     {
         // expiration is a string
         // https://www.rabbitmq.com/amqp-0-9-1-reference.html#domain.shortstr
@@ -227,7 +227,7 @@ final class AmqpMessage implements InteropAmqpMessage
         return $this->deliveryTag;
     }
 
-    public function setDeliveryTag(int $deliveryTag = null): void
+    public function setDeliveryTag(?int $deliveryTag = null): void
     {
         $this->deliveryTag = $deliveryTag;
     }
@@ -237,7 +237,7 @@ final class AmqpMessage implements InteropAmqpMessage
         return $this->consumerTag;
     }
 
-    public function setConsumerTag(string $consumerTag = null): void
+    public function setConsumerTag(?string $consumerTag = null): void
     {
         $this->consumerTag = $consumerTag;
     }
@@ -267,7 +267,7 @@ final class AmqpMessage implements InteropAmqpMessage
         return $this->routingKey;
     }
 
-    public function setRoutingKey(string $routingKey = null): void
+    public function setRoutingKey(?string $routingKey = null): void
     {
         $this->routingKey = $routingKey;
     }

--- a/src/Impl/AmqpQueue.php
+++ b/src/Impl/AmqpQueue.php
@@ -45,7 +45,7 @@ final class AmqpQueue implements InteropAmqpQueue
         return $this->consumerTag;
     }
 
-    public function setConsumerTag(string $consumerTag = null): void
+    public function setConsumerTag(?string $consumerTag = null): void
     {
         $this->consumerTag = $consumerTag;
     }


### PR DESCRIPTION
Resolves PHP 8.4 deprecation: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated