### PR TITLE
Allow setting of queue name

### DIFF
--- a/src/AmqpQueue.php
+++ b/src/AmqpQueue.php
@@ -29,4 +29,6 @@ interface AmqpQueue extends Queue, AmqpDestination
     public function getConsumerTag(): ?string;
 
     public function setConsumerTag(?string $consumerTag = null): void;
+
+    public function setQueueName(string $queueName): void;
 }

--- a/src/Impl/AmqpQueue.php
+++ b/src/Impl/AmqpQueue.php
@@ -40,6 +40,11 @@ final class AmqpQueue implements InteropAmqpQueue
         return $this->name;
     }
 
+    public function setQueueName(?string $queueName): void
+    {
+	$this->name = $queueName;
+    }
+
     public function getConsumerTag(): ?string
     {
         return $this->consumerTag;

--- a/src/Impl/AmqpQueue.php
+++ b/src/Impl/AmqpQueue.php
@@ -42,7 +42,7 @@ final class AmqpQueue implements InteropAmqpQueue
 
     public function setQueueName(?string $queueName): void
     {
-	$this->name = $queueName;
+        $this->name = $queueName;
     }
 
     public function getConsumerTag(): ?string


### PR DESCRIPTION
Unlike, perhaps, most queues, AMQP allows empty string for an initial queue name, which is then replaced with an automatically generated queue name. For this reason, we need this public function.